### PR TITLE
Replace gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,6 @@ function getMatches(str, re) {
   while ((match = re.exec(str)) !== null) {
     results.push(match[1]);
   }
-  // console.log('matches: ', results);
   return results;
 }
 
@@ -82,18 +81,12 @@ function getMatches(str, re) {
  * @param modulesDirectory
  */
 function transformFile(from, to, modulesDirectory) {
-  // console.log('from: ' + from);
-  // console.log('to: ' + to);
   var contents = fs.readFileSync(from, 'utf8');
 
   // modules
   var modules = getModules(contents);
   for (var index in modules) {
     var module = modules[index];
-    // console.log('transformFile:modulesManifest: ' + Object.keys(modulesManifest));
-    // console.log('transformFile:module: ' + module);
-    // console.log('transformFile:modulesManifest:module: ' + modulesManifest[module]);
-
     if (modulesManifest.hasOwnProperty(module)) {
       continue;
     }
@@ -102,17 +95,12 @@ function transformFile(from, to, modulesDirectory) {
       continue;
     }
     var targetPath = path_util.targetPath(modulePath, node_modules, modulesDirectory);
-    // console.log('transformFile:targetPath: ' + targetPath);
     modulesManifest[module] = path.relative(process.cwd(), targetPath);
     if (!fs.existsSync(targetPath)) {
       transformFile(modulePath, targetPath, modulesDirectory);
     }
-    // console.log('transformFile:module: ' + module);
     var relativePath = path_util.relativePath(to, targetPath);
-    // console.log('transformFile:relativePath: ' + relativePath);
-    // console.log('transformFile:to: ' + to);
     var re = eval('\/require\\\(\[\'\"\]' + module + '\[\'\"\]\\\)\/ig');
-    // console.log('transformFile:re: ' + re);
     contents = contents.replace(re, 'require(\'' + relativePath + '\')');
   }
 
@@ -121,7 +109,6 @@ function transformFile(from, to, modulesDirectory) {
   for (var index in requires) {
     var require = requires[index];
     var requirePath = path_util.requirePath(from, require);
-    // console.log('requirePath: ' + requirePath);
     if (requirePath === null) {
       continue;
     }
@@ -137,7 +124,6 @@ function transformFile(from, to, modulesDirectory) {
   }
 
   var dirname = path.dirname(to);
-  // console.log('dirname: ' + dirname);
   fs.mkdirsSync(dirname);
   fs.writeFileSync(to, contents, 'utf8');
 }
@@ -152,7 +138,6 @@ function plugin(opts) {
     distDirectory: 'dist'
   }, opts);
 
-  // console.log('opts: ' , opts);
   return through.obj(function (file, enc, cb) {
     if (file.isStream()) {
       this.emit('error', new PluginError(PLUGIN_NAME, 'Streams are not supported!'));
@@ -182,26 +167,18 @@ function plugin(opts) {
         var relativePath = path.relative(path.join(cwd, opts.fromDirectory || ''), filePath);
         var distFilePath = path.join(process.cwd(), distDirectory, relativePath);
       }
-      // console.log('distDirectory: ' + distDirectory);
-      // console.log('relativePath: ' + relativePath);
-      // console.log('distFilePath: ' + distFilePath);
       var distFileDirname = path.dirname(distFilePath);
-      // console.log('distFileDirname: ' + distFileDirname);
 
       // modules
       var modules = getModules(contents);
       for (var index in modules) {
         var module = modules[index];
-        // console.log('module: ' + module);
 
         var modulePath = path_util.modulePath(module, node_modules);
         if (modulePath === null) {
           continue;
         }
-        // console.log('modulePath: ' + modulePath);
-
         var targetPath = path_util.targetPath(modulePath, node_modules, modulesDirectory);
-        // console.log('targetPath: ' + targetPath);
 
         if (!modulesManifest.hasOwnProperty(module)) {
           var relativePath = path.relative(process.cwd(), targetPath);
@@ -214,29 +191,20 @@ function plugin(opts) {
 
         if (opts.dist) { // replace modules with path
           var relativePath = path_util.relativePath(distFileDirname, targetPath);
-          // relativePath = path.join('./', relativePath);
-          // console.log('distFilePath: ' + distFilePath);
-          // console.log('relativePath: ' + relativePath);
-          // var re = /require\(['"]( + module + )['"]\)/ig;
           var re = eval('\/require\\\(\[\'\"\]' + module + '\[\'\"\]\\\)\/ig');
           contents = contents.replace(re, 'require(\'' + relativePath + '\')');
         }
       }
-      // console.log(contents);
 
       // subModules
       var subModules = getSubModules(contents);
       for (var index in subModules) {
         var subModule = subModules[index];
-        // console.log('subModule: ' + subModule);
         var subModulePath = path_util.subModulePath(subModule, node_modules);
         if (subModulePath === null) {
           continue;
         }
-        // console.log('subModulePath: ' + subModulePath);
-
         var targetPath = path_util.targetPath(subModulePath, node_modules, modulesDirectory);
-        // console.log('targetPath: ' + targetPath);
 
         if (!modulesManifest.hasOwnProperty(subModule)) {
           var relativePath = path.relative(process.cwd(), targetPath);
@@ -249,20 +217,13 @@ function plugin(opts) {
 
         if (opts.dist) { // replace modules with path
           var relativePath = path_util.relativePath(distFileDirname, targetPath);
-          // relativePath = path.join('./', relativePath);
-          // console.log('distFilePath: ' + distFilePath);
-          // console.log('relativePath: ' + relativePath);
-          // var re = /require\(['"]( + module + )['"]\)/ig;
           var subModuleRegex = subModule.replace('/', '\\\/');
           var subModuleRegex = subModuleRegex.replace('.', '\\\.');
           var re = 'require\\\(\[\'\"\]' + subModuleRegex + '\[\'\"\]\\\)';
-          // console.log('re: ' + re);
           var regex = new RegExp(re, 'ig');
-          // console.log('regex: ' + regex);
           contents = contents.replace(regex, 'require(\'' + relativePath + '\')');
         }
       }
-      // console.log(contents);
       file.contents = Buffer.from(contents);
       fs.writeFileSync(modulesManifestPath, JSON.stringify(modulesManifest, null, 2), 'utf8');
     }

--- a/index.js
+++ b/index.js
@@ -3,14 +3,13 @@
  */
 
 var through = require('through2');
-var gutil = require('gulp-util');
 var objectAssign = require('object-assign');
 var testSubMobile = require('gulp-util/lib/log');
 var testSubMobile2 = require('ini/ini');
 var fs = require('fs-extra');
 var path = require('path');
 var path_util = require('./path');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 
 var PLUGIN_NAME = 'gulp-require-modules';
 var node_modules = process.cwd() + '/node_modules/';

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "assert": "^1.4.1",
     "gulp": "^3.9.1",
-    "mocha": "^3.1.2"
+    "mocha": "^3.1.2",
+    "vinyl-file": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "homepage": "https://github.com/GreedBell/gulp-require-modules#readme",
   "dependencies": {
     "fs-extra": "^0.30.0",
-    "gulp-util": "^3.0.7",
     "object-assign": "^4.1.0",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
### Changes Made
* As suggested by npm, gulp-util is deprecated and should be replaced. The only use in the project was for plugin error logging, so it was replaced with the plugin-error module.
* Removed commented out code and console.logs to make the file a little cleaner and smaller for those installing the project.
* Installed vinyl-file as a devDependency. It was required to be able to run the mocha test.

